### PR TITLE
Remove Keyspace from state when performing delete

### DIFF
--- a/internal/provider/resource_keyspace.go
+++ b/internal/provider/resource_keyspace.go
@@ -94,6 +94,7 @@ func resourceKeyspaceRead(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func resourceKeyspaceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
This won't actually delete the Keyspace since it's not supported in the API at the moment. But at least the state will be removed.