### PR TITLE
do not retry on POST

### DIFF
--- a/internal/provider/data_source_secure_connect_bundle_url.go
+++ b/internal/provider/data_source_secure_connect_bundle_url.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/joeandaverde/astra-client-go/v2/astra"
@@ -40,18 +42,36 @@ func dataSourceSecureConnectBundleURLRead(ctx context.Context, d *schema.Resourc
 
 	databaseID := d.Get("database_id").(string)
 
-	resp, err := client.GenerateSecureBundleURLWithResponse(ctx, astra.DatabaseIdParam(databaseID))
-	if err != nil {
+	var credsURL *astra.CredsURL
+	if err := resource.RetryContext(ctx, time.Minute, func() *resource.RetryError {
+		resp, err := client.GenerateSecureBundleURLWithResponse(ctx, astra.DatabaseIdParam(databaseID))
+		if err != nil || resp.StatusCode() >= 500 {
+			return resource.RetryableError(err)
+		}
+
+		// 409 Conflict can be returned if the database is not yet ready
+		if resp.JSON409 != nil {
+			return resource.RetryableError(fmt.Errorf("cannot create secure bundle url: %s", string(resp.Body)))
+		}
+
+		// Any other 400 status code is not retried
+		if resp.StatusCode() >= 400 {
+			return resource.NonRetryableError(fmt.Errorf("error trying to create secure bundle url: %s", string(resp.Body)))
+		}
+
+		// Any response other than 200 is unexpected
+		credsURL := resp.JSON200
+		if credsURL == nil {
+			return resource.NonRetryableError(fmt.Errorf("unexpected response creating secure bundle url: %s", string(resp.Body)))
+		}
+
+		return nil
+	}); err != nil {
 		return diag.FromErr(err)
 	}
 
-	bundleURL := resp.JSON200
-	if bundleURL == nil {
-		return diag.Errorf("failed to get secure connect bundle: %s", string(resp.Body))
-	}
-
-	d.SetId(fmt.Sprintf("%s/secure-connect-bundle/%s", databaseID, keyFromStrings([]string{bundleURL.DownloadURL})))
-	d.Set("url", bundleURL.DownloadURL)
+	d.SetId(fmt.Sprintf("%s/secure-connect-bundle/%s", databaseID, keyFromStrings([]string{credsURL.DownloadURL})))
+	d.Set("url", credsURL.DownloadURL)
 
 	return nil
 }

--- a/internal/provider/data_source_secure_connect_bundle_url.go
+++ b/internal/provider/data_source_secure_connect_bundle_url.go
@@ -60,7 +60,7 @@ func dataSourceSecureConnectBundleURLRead(ctx context.Context, d *schema.Resourc
 		}
 
 		// Any response other than 200 is unexpected
-		credsURL := resp.JSON200
+		credsURL = resp.JSON200
 		if credsURL == nil {
 			return resource.NonRetryableError(fmt.Errorf("unexpected response creating secure bundle url: %s", string(resp.Body)))
 		}
@@ -72,6 +72,5 @@ func dataSourceSecureConnectBundleURLRead(ctx context.Context, d *schema.Resourc
 
 	d.SetId(fmt.Sprintf("%s/secure-connect-bundle/%s", databaseID, keyFromStrings([]string{credsURL.DownloadURL})))
 	d.Set("url", credsURL.DownloadURL)
-
 	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,6 +69,13 @@ func configure(providerVersion string, p *schema.Provider) func(context.Context,
 		// handle intermittent api errors
 		retryClient := retryablehttp.NewClient()
 		retryClient.RetryMax = 10
+		retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+			// Never retry POST requests because of side effects
+			if resp.Request.Method == "POST" {
+				return false, err
+			}
+			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+		}
 
 		client, err := astra.NewClientWithResponses(astra.ServerURL, func(c *astra.Client) error {
 			c.Client = retryClient.StandardClient()


### PR DESCRIPTION
The create database API will allow multiple create with the same parameters. This PR prevents POST requests that by definition have side effects from being retried.