### PR TITLE
Fix token management as token IDs are case-sensitive in Astra

### DIFF
--- a/internal/provider/resource_token.go
+++ b/internal/provider/resource_token.go
@@ -148,7 +148,7 @@ func setTokenData(d *schema.ResourceData, tokenMap map[string]interface{}) error
 }
 
 func parseTokenID(id string) (string, error) {
-	idParts := strings.Split(strings.ToLower(id), "/")
+	idParts := strings.Split(id, "/")
 	if len(idParts) != 1 {
 		return "",  errors.New("invalid token id format: expected clientID/")
 	}


### PR DESCRIPTION
Fixes #33 

When removing a token from the terraform file, running `terraform apply` indicates it will delete/destroy the token, but the token is not destroyed. What I noticed when trying to apply the change is that the token ID reports as being changed:

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # astra_token.example has been changed
  ~ resource "astra_token" "example" {
      ~ id        = "YSZxhKSXnxsNBCahkxrBasnh" -> "yszxhksxnxsnbcahkxrbasnh"
        # (4 unchanged attributes hidden)
    }
```

The problem is that the ID should not be detected as changed. It is detected as changed because the ID is `toLowerCase`ed when it is returned after creating it ([see here](https://github.com/datastax/terraform-provider-astra/blob/main/internal/provider/resource_token.go#L151)).

Removing the `toLowerCase` resolves the issue.