### PR TITLE
Add Multi-region support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ under Terraform plugin management.
 
 For each Datatbase under Terraform management:
 1. Obtain the database id (ex. b3107622-429d-45ab-a6da-0252cb091c86)
-2. Obtain the terraform resource name for the database (ex. "my_db", from the resouirce line in your terraform .tf file)
-3. Remove the databse from the terrafrom state
+2. Obtain the Terraform resource name for the database (ex. "my_db", from the resource line in your Terraform .tf file)
+3. Remove the database from the Terraform state
 ```sh
-   terrafrom state rm astra_database.<resource name from #2>
+   terraform state rm astra_database.<resource name from #2>
 ```
-4. Edit your terrafrom resource file and convert the "region" field value from a string to an array
+4. Edit your Terraform resource file and convert the "region" field value from a string to an array
 ```sh
    region = "us-east1"
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
-## 0.1.0 (Unreleased)
+## 1.0.14
+[Feature] Add multi-region support
 
 BACKWARDS INCOMPATIBILITIES / NOTES:
+
+The Multi-Region support feature has changed the Terraform resource structure for Databases.
+Specifically, the "region" field is now an array of strings, as opposed to a single string.
+When updating the plugin, from a version prior to 1.0.14, to version 1.0.14 or newer, you
+will have to perform a manual Terraform state migration in order to keep existing databases
+under Terraform plugin management.
+
+For each Datatbase under Terraform management:
+1. Obtain the database id (ex. b3107622-429d-45ab-a6da-0252cb091c86)
+2. Obtain the terraform resource name for the database (ex. "my_db", from the resouirce line in your terraform .tf file)
+3. Remove the databse from the terrafrom state
+```sh
+   terrafrom state rm astra_database.<resource name from #2>
+```
+4. Edit your terrafrom resource file and convert the "region" field value from a string to an array
+```sh
+   region = "us-east1"
+```
+to
+```sh
+   region = ["us-east1"]
+```
+5. Import the database back into the Terraform state
+```sh
+   terraform import astra_database.<resource name from #2> <database uuid from #1>
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/datastax/terraform-provider-astra
 go 1.16
 
 require (
-	github.com/datastax/astra-client-go/v2 v2.2.7
+	github.com/datastax/astra-client-go/v2 v2.2.8
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/hashicorp/terraform-plugin-docs v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
-github.com/datastax/astra-client-go/v2 v2.2.7 h1:qTncsK0IH3Kuq3JsfU1RY5q6hSEEcoTZ4+xeRoWGghM=
-github.com/datastax/astra-client-go/v2 v2.2.7/go.mod h1:6Ja4wfAU375DVpc+QTaAn6vm/yuTP0mUfV2NWq3qT80=
+github.com/datastax/astra-client-go/v2 v2.2.8 h1:EwMyj0flELQNe8Nj/c4CsXVtEgCXSoHZc/p16hcXb/A=
+github.com/datastax/astra-client-go/v2 v2.2.8/go.mod h1:6Ja4wfAU375DVpc+QTaAn6vm/yuTP0mUfV2NWq3qT80=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/provider/resource_access_list.go
+++ b/internal/provider/resource_access_list.go
@@ -141,11 +141,11 @@ func resourceAccessListDelete(ctx context.Context, d *schema.ResourceData, meta 
 	if len(aResp) > 0 {
 		for _, v := range aResp {
 			addressesQP:= astra.AddressesQueryParam{*v.Address}
-			params :=  &astra.DeleteAddressesOrAccessListForDatabaseParams{&addressesQP}
+			params :=  &astra.DeleteAddressesOrAccessListForDatabaseParams{Addresses: &addressesQP}
 			client.DeleteAddressesOrAccessListForDatabase(ctx, astra.DatabaseIdParam(databaseID), params)
 		}
 	} else {
-		params :=  &astra.DeleteAddressesOrAccessListForDatabaseParams{nil}
+		params :=  &astra.DeleteAddressesOrAccessListForDatabaseParams{Addresses: nil}
 		client.DeleteAddressesOrAccessListForDatabase(ctx, astra.DatabaseIdParam(databaseID), params)
 	}
 

--- a/internal/provider/resource_database.go
+++ b/internal/provider/resource_database.go
@@ -30,6 +30,7 @@ func resourceDatabase() *schema.Resource {
 		CreateContext: resourceDatabaseCreate,
 		ReadContext:   resourceDatabaseRead,
 		DeleteContext: resourceDatabaseDelete,
+		UpdateContext: resourceDatabaseUpdate,
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -66,9 +67,12 @@ func resourceDatabase() *schema.Resource {
 			},
 			"region": {
 				Description: "Cloud region to launch the database.",
-				Type:        schema.TypeString,
+				Type:        schema.TypeList,
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 
 			// Computed
@@ -140,29 +144,33 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 	name := d.Get("name").(string)
 	keyspace := d.Get("keyspace").(string)
 	cloudProvider := d.Get("cloud_provider").(string)
-	region := d.Get("region").(string)
+	regions := d.Get("region").([] interface{})
 
-	// Temporarily  disable region check
-	regionsResp, err := client.ListServerlessRegionsWithResponse(ctx)
-	if err != nil {
-		return diag.FromErr(err)
-	} else if regionsResp.StatusCode() != 200 {
-		return diag.Errorf("unexpected list available regions response: %s", string(regionsResp.Body))
+	if len(regions) < 1 {
+		return diag.Errorf("\"region\" array must have at least 1 region specified")
 	}
-	dbRegion := findMatchingRegion(cloudProvider, region, "serverless", *regionsResp.JSON200)
-	if dbRegion == nil {
-		return diag.Errorf("cloud provider and region combination not available: %s/%s", cloudProvider, region)
+
+	// Make sure all regions are valid
+	if err := ensureValidRegions(ctx, client, d); err != nil {
+		return err
+	}
+	// get the first region in the list to use as the region in which to create the database
+	region := regions[0].(string)
+
+	// make an array of additonal regions to add if more than one specified
+	additionalRegions := make([]string, len(regions) -1)
+	if len(additionalRegions) > 0 {
+		for i:=0; i<len(additionalRegions); i++ {
+			additionalRegions[i] = regions[i+1].(string)
+		}
 	}
 
 	resp, err := client.CreateDatabaseWithResponse(ctx, astra.CreateDatabaseJSONRequestBody{
 		Name:          name,
 		Keyspace:      keyspace,
-		//CloudProvider: astra.DatabaseInfoCreateCloudProvider(dbRegion.CloudProvider),
 		CloudProvider: astra.DatabaseInfoCreateCloudProvider(cloudProvider),
 		CapacityUnits: 1,
-		//Region:        dbRegion.Region,
 		Region:        region,
-	    //Tier:          astra.DatabaseInfoCreateTier(dbRegion.Tier),
 		Tier:          astra.DatabaseInfoCreateTier("serverless"),
 	})
 	if err != nil {
@@ -175,39 +183,15 @@ func resourceDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta in
 	databaseID := resp.HTTPResponse.Header.Get("location")
 
 	// Wait for the database to be ACTIVE then set resource data
-	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		res, err := client.GetDatabaseWithResponse(ctx, astra.DatabaseIdParam(databaseID))
-		// Errors sending request should be retried and are assumed to be transient
-		if err != nil {
-			return resource.RetryableError(err)
-		}
+	if err := waitForDatabaseAndUpdateResource(ctx, d, client, databaseID); err != nil {
+		return err
+	}
 
-		// Status code >=5xx are assumed to be transient
-		if res.StatusCode() >= 500 {
-			return resource.RetryableError(fmt.Errorf("error while fetching database: %s", string(res.Body)))
+	// Add any additional regions/datacenters
+	if len(additionalRegions) > 0 {
+		if err:= addRegionsToDatabase(ctx, d, client, additionalRegions, databaseID, cloudProvider); err != nil {
+			return err
 		}
-
-		// Status code > 200 NOT retried
-		if res.StatusCode() > 200 || res.JSON200 == nil {
-			return resource.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
-		}
-
-		// Success fetching database
-		db := res.JSON200
-		switch db.Status {
-		case astra.StatusEnumERROR, astra.StatusEnumTERMINATED, astra.StatusEnumTERMINATING:
-			// If the database reached a terminal state it will never become active
-			return resource.NonRetryableError(fmt.Errorf("database failed to reach active status: status=%s", db.Status))
-		case astra.StatusEnumACTIVE:
-			if err := setDatabaseResourceData(d, db); err != nil {
-				return resource.NonRetryableError(err)
-			}
-			return nil
-		default:
-			return resource.RetryableError(fmt.Errorf("expected database to be active but is %s", db.Status))
-		}
-	}); err != nil {
-		return diag.FromErr(err)
 	}
 
 	return nil
@@ -231,7 +215,7 @@ func resourceDatabaseRead(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		// Retry on 5XX errors
-		if resp.StatusCode() >= 500 {
+		if resp.StatusCode() >= http.StatusInternalServerError {
 			return resource.RetryableError(fmt.Errorf("error fetching database (%s): %v", databaseID, err))
 		}
 
@@ -273,7 +257,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		// Status code 5XX are considered transient
-		if resp.StatusCode() >= 500 {
+		if resp.StatusCode() >= http.StatusInternalServerError {
 			return resource.RetryableError(fmt.Errorf("error terminating database: %s", string(resp.Body)))
 		}
 
@@ -284,7 +268,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		// All other 4XX status codes are NOT retried
-		if resp.StatusCode() >= 400 {
+		if resp.StatusCode() >= http.StatusBadRequest {
 			return resource.NonRetryableError(fmt.Errorf("unexpected response attempting to terminate database: %s", string(resp.Body)))
 		}
 
@@ -308,7 +292,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		// Status code >=5xx are assumed to be transient
-		if res.StatusCode() >= 500 {
+		if res.StatusCode() >= http.StatusInternalServerError {
 			return resource.RetryableError(fmt.Errorf("error while fetching database: %s", string(res.Body)))
 		}
 
@@ -318,7 +302,7 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		// All other status codes > 200 NOT retried
-		if res.StatusCode() > 200 || res.JSON200 == nil {
+		if res.StatusCode() > http.StatusOK || res.JSON200 == nil {
 			return resource.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
 		}
 
@@ -335,6 +319,161 @@ func resourceDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	d.SetId("")
+	return nil
+}
+
+func resourceDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*astra.ClientWithResponses)
+	databaseID := d.Id()
+	cloudProvider := d.Get("cloud_provider").(string)
+
+	if d.HasChangeExcept("region") {
+		// only region changes supported at the moment
+		return diag.Errorf("Update of Database resource only supported for fields: %s", "region")
+	}
+
+	if d.HasChange("region") {
+		// get regions to add and delete
+		regionsToAdd, regionsToDelete := getRegionUpdates(d.GetChange("region"))
+		if len(regionsToAdd) > 0 {
+			// add any regions to add first
+			if err := addRegionsToDatabase(ctx, d, client, regionsToAdd, databaseID, cloudProvider); err != nil {
+				return err
+			}
+		}
+		if len(regionsToDelete) > 0 {
+			// delete any regions that should be removed
+			if err := deleteRegionsFromDatabase(ctx, d, client, regionsToDelete, databaseID, cloudProvider); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func getRegionUpdates(oldRegions interface{}, newRegions interface{}) ([]string, []string){
+	mOld := map[string]bool{}
+	mNew := map[string]bool{}
+	var regionsToAdd []string
+	var regionsToDelete []string
+	// find any regions to add
+	for _, v := range oldRegions.([]interface{}) {
+		mOld[v.(string)] = true
+	}
+	for _, v := range newRegions.([]interface{}) {
+		mNew[v.(string)] = true
+	}
+	for _, v := range oldRegions.([]interface{}) {
+		if !mNew[v.(string)] {
+			regionsToDelete = append(regionsToDelete, v.(string))
+		}
+	}
+	for _, v := range newRegions.([]interface{}) {
+		if !mOld[v.(string)] {
+			regionsToAdd = append(regionsToAdd, v.(string))
+		}
+	}
+
+	return regionsToAdd, regionsToDelete
+}
+
+func addRegionsToDatabase(ctx context.Context, d *schema.ResourceData, client *astra.ClientWithResponses, regions []string, databaseID string, cloudProvider string) diag.Diagnostics {
+	// make sure the regions are valid
+	if err := ensureValidRegions(ctx, client, d); err != nil {
+		return err
+	}
+	datacenters := make([]astra.Datacenter, len(regions))
+	for index, region := range regions {
+		datacenters[index] = astra.Datacenter {
+			CloudProvider: cloudProvider,
+			Region:        region,
+			Tier:          "serverless",
+		}
+	}
+	// add the regions
+	resp, err := client.AddDatacentersWithResponse(ctx, astra.DatabaseIdParam(databaseID), datacenters)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return diag.FromErr(fmt.Errorf("Unexpected response addinng Regions: %s", string(resp.Body)))
+	}
+	// Wait for the database to be ACTIVE then set resource data
+	if err := waitForDatabaseAndUpdateResource(ctx, d, client, databaseID); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deleteRegionsFromDatabase(ctx context.Context, d *schema.ResourceData, client *astra.ClientWithResponses, regions []string, databaseID string, cloudProvider string) diag.Diagnostics {
+	// get all the datacenetrs for the Datbase ID
+	dcListResp, err := client.ListDatacentersWithResponse(ctx, astra.DatabaseIdParam(databaseID), &astra.ListDatacentersParams{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if dcListResp.StatusCode() != http.StatusOK || dcListResp.JSON200 == nil {
+		return diag.FromErr(fmt.Errorf("Unexpected response fetching Datacenters: %s", dcListResp.Body))
+	}
+	dcs := *dcListResp.JSON200
+	// map DCs to region
+	m := map[string]astra.Datacenter{}
+	for _, v := range dcs {
+		m[v.Region] = v
+	}
+	// delete each region that exists
+	for _, v := range regions {
+		if dc := m[v]; dc.Id != nil {
+			termResp, err := client.TerminateDatacenterWithResponse(ctx, astra.DatabaseIdParam(databaseID), astra.DatacenterIdParam(*dc.Id))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			if termResp.StatusCode() != http.StatusAccepted {
+				return diag.FromErr(fmt.Errorf("Error terminating datacenter for region \"%s\": %s", v, string(termResp.Body)))
+			}
+			// Wait for the database to be ACTIVE then set resource data
+			if err := waitForDatabaseAndUpdateResource(ctx, d, client, databaseID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func waitForDatabaseAndUpdateResource(ctx context.Context, d *schema.ResourceData, client *astra.ClientWithResponses, databaseID string) diag.Diagnostics {
+	if err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		res, err := client.GetDatabaseWithResponse(ctx, astra.DatabaseIdParam(databaseID))
+		// Errors sending request should be retried and are assumed to be transient
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+
+		// Status code >=5xx are assumed to be transient
+		if res.StatusCode() >= http.StatusInternalServerError {
+			return resource.RetryableError(fmt.Errorf("error while fetching database: %s", string(res.Body)))
+		}
+
+		// Status code > 200 NOT retried
+		if res.StatusCode() > http.StatusOK || res.JSON200 == nil {
+			return resource.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
+		}
+
+		// Success fetching database
+		db := res.JSON200
+		switch db.Status {
+		case astra.StatusEnumERROR, astra.StatusEnumTERMINATED, astra.StatusEnumTERMINATING:
+			// If the database reached a terminal state it will never become active
+			return resource.NonRetryableError(fmt.Errorf("database failed to reach active status: status=%s", db.Status))
+		case astra.StatusEnumACTIVE:
+			if err := setDatabaseResourceData(d, db); err != nil {
+				return resource.NonRetryableError(err)
+			}
+			return nil
+		default:
+			return resource.RetryableError(fmt.Errorf("expected database to be active but is %s", db.Status))
+		}
+	}); err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 
@@ -364,7 +503,7 @@ func flattenDatabase(db *astra.Database) map[string]interface{} {
 		"data_endpoint_url":    astra.StringValue(db.DataEndpointUrl),
 		"cqlsh_url":            astra.StringValue(db.CqlshUrl),
 		"cloud_provider":       "",
-		"region":               astra.StringValue(db.Info.Region),
+		"region":               [1]string{astra.StringValue(db.Info.Region)},
 		"keyspace":             astra.StringValue(db.Info.Keyspace),
 		"additional_keyspaces": astra.StringSlice(db.Info.AdditionalKeyspaces),
 	}
@@ -374,7 +513,35 @@ func flattenDatabase(db *astra.Database) map[string]interface{} {
 		flatDB["cloud_provider"] = string(cloudProvider)
 	}
 
+	if db.Info.Datacenters != nil && len(*db.Info.Datacenters) > 1 {
+		regions := make([]string, len(*db.Info.Datacenters))
+		for index, dc := range *db.Info.Datacenters {
+			regions[index] = dc.Region
+		}
+		flatDB["region"] = regions
+	}
 	return flatDB
+}
+
+func ensureValidRegions(ctx context.Context, client *astra.ClientWithResponses, d *schema.ResourceData) diag.Diagnostics {
+	// get the list of serveless regions
+	regionsResp, err := client.ListServerlessRegionsWithResponse(ctx)
+	if err != nil {
+		return diag.FromErr(err)
+	} else if regionsResp.StatusCode() != http.StatusOK {
+		return diag.Errorf("unexpected list available regions response: %s", string(regionsResp.Body))
+	}
+	// make sure all of the regions are valid
+	cloudProvider := d.Get("cloud_provider").(string)
+	regions := d.Get("region").([] interface{})
+	for _, r := range regions {
+		region := r.(string)
+		dbRegion := findMatchingRegion(cloudProvider, region, "serverless", *regionsResp.JSON200)
+		if dbRegion == nil {
+			return diag.Errorf("cloud provider and region combination not available: %s/%s", cloudProvider, region)
+		}
+	}
+	return nil
 }
 
 func findMatchingRegion(provider, region, tier string, availableRegions []astra.ServerlessRegion) *astra.ServerlessRegion{

--- a/internal/provider/resource_database.go
+++ b/internal/provider/resource_database.go
@@ -382,25 +382,25 @@ func addRegionsToDatabase(ctx context.Context, d *schema.ResourceData, client *a
 	if err := ensureValidRegions(ctx, client, d); err != nil {
 		return err
 	}
-	datacenters := make([]astra.Datacenter, len(regions))
-	for index, region := range regions {
-		datacenters[index] = astra.Datacenter {
+	// Currently, DevOps API only allows for adding 1 region at a time
+	for _, region := range regions {
+		datacenters := make([]astra.Datacenter, 1)
+		datacenters[0] = astra.Datacenter {
 			CloudProvider: cloudProvider,
 			Region:        region,
 			Tier:          "serverless",
 		}
-	}
-	// add the regions
-	resp, err := client.AddDatacentersWithResponse(ctx, astra.DatabaseIdParam(databaseID), datacenters)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if resp.StatusCode() != http.StatusCreated {
-		return diag.FromErr(fmt.Errorf("Unexpected response addinng Regions: %s", string(resp.Body)))
-	}
-	// Wait for the database to be ACTIVE then set resource data
-	if err := waitForDatabaseAndUpdateResource(ctx, d, client, databaseID); err != nil {
-		return err
+		resp, err := client.AddDatacentersWithResponse(ctx, astra.DatabaseIdParam(databaseID), datacenters)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if resp.StatusCode() != http.StatusCreated {
+			return diag.FromErr(fmt.Errorf("Unexpected response addinng Regions: %s", string(resp.Body)))
+		}
+		// Wait for the database to be ACTIVE then set resource data
+		if err := waitForDatabaseAndUpdateResource(ctx, d, client, databaseID); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/provider/resource_database_test.go
+++ b/internal/provider/resource_database_test.go
@@ -25,7 +25,7 @@ resource "astra_database" "dev" {
   name           = "puppies"
   keyspace       = "puppies"
   cloud_provider = "gcp"
-  region         = "us-east1"
+  region         = ["us-east1"]
 }
 
 data "astra_secure_connect_bundle_url" "dev" {

--- a/internal/provider/resource_database_test.go
+++ b/internal/provider/resource_database_test.go
@@ -33,3 +33,112 @@ data "astra_secure_connect_bundle_url" "dev" {
 }
 `)
 }
+
+func TestGetRegionUpdatesOnlyDeletes(t *testing.T) {
+	oldData := []interface{} {"region1", "region2", "region3", "region4", "region5"}
+	newData := []interface{} {"region1", "region2", "region3"}
+
+	regionsToAdd, regionsToDelete := getRegionUpdates(oldData, newData)
+
+	testFailed := false
+	// verify no adds and 2 deletes
+	if len(regionsToAdd) != 0 {
+		testFailed = true
+		t.Logf("getRegionUpdates returned regions to add, but expected none. Regions to add: %v", regionsToAdd)
+	}
+	if len(regionsToDelete) != 2 {
+		testFailed = true
+		t.Logf("getRegionUpdates returned an unexpected number of regions to delete. Expected [region4 region5] but got: %v", regionsToDelete)
+	} else {
+		// make sure it's the correct regions
+		expectedMap := map[string]bool{}
+		expectedMap["region4"] = true
+		expectedMap["region5"] = true
+		for _, v := range regionsToDelete {
+			if !expectedMap[v] {
+				testFailed = true
+				t.Logf("Unexpected region to delete: %s", v)
+			}
+		}
+	}
+
+	if testFailed {
+		t.Fail()
+	}
+}
+
+func TestGetRegionUpdatesOnlyAdds(t *testing.T) {
+	oldData := []interface{} {"region1", "region2", "region3"}
+	newData := []interface{} {"region1", "region2", "region3", "region4", "region5"}
+
+	regionsToAdd, regionsToDelete := getRegionUpdates(oldData, newData)
+
+	testFailed := false
+	// verify no deletes and 2 adds
+	if len(regionsToAdd) != 2 {
+		testFailed = true
+		t.Logf("getRegionUpdates returned an unexpected number of regions to add. Expected [region4 region5] but got]: %v", regionsToAdd)
+	} else {
+		// make sure it's the correct regions
+		expectedMap := map[string]bool{}
+		expectedMap["region4"] = true
+		expectedMap["region5"] = true
+		for _, v := range regionsToAdd {
+			if !expectedMap[v] {
+				testFailed = true
+				t.Logf("Unexpected region to add: %s", v)
+			}
+		}
+	}
+	if len(regionsToDelete) != 0 {
+		testFailed = true
+		t.Logf("getRegionUpdates returned regions to delete, but expected none. Regions to delete: %v", regionsToDelete)
+	}
+
+	if testFailed {
+		t.Fail()
+	}
+}
+
+func TestGetRegionUpdatesAddsAndDeletes(t *testing.T) {
+	oldData := []interface{} {"region1", "region3", "region5"}
+	newData := []interface{} {"region1", "region2", "region4"}
+
+	regionsToAdd, regionsToDelete := getRegionUpdates(oldData, newData)
+
+	testFailed := false
+	// verify 2 adds and 2 deletes
+	if len(regionsToAdd) != 2 {
+		testFailed = true
+		t.Logf("getRegionUpdates returned an unexpected number of regions to add. Expected [region2 region4] but got]: %v", regionsToAdd)
+	} else {
+		// make sure it's the correct regions
+		expectedMap := map[string]bool{}
+		expectedMap["region2"] = true
+		expectedMap["region4"] = true
+		for _, v := range regionsToAdd {
+			if !expectedMap[v] {
+				testFailed = true
+				t.Logf("Unexpected region to add: %s", v)
+			}
+		}
+	}
+	if len(regionsToDelete) != 2 {
+		testFailed = true
+		t.Logf("getRegionUpdates returned an unexpected number of regions to delete. Expected [region3 region5] but got]: %v", regionsToDelete)
+	} else {
+		// make sure it's the correct regions
+		expectedMap := map[string]bool{}
+		expectedMap["region3"] = true
+		expectedMap["region5"] = true
+		for _, v := range regionsToDelete {
+			if !expectedMap[v] {
+				testFailed = true
+				t.Logf("Unexpected region to delete: %s", v)
+			}
+		}
+	}
+	if testFailed {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Converts the `region` field of a terraform database resource from a String to an array to allow for deploying Astra to multiple regions.

Fixes #35