### PR TITLE
Fix Go module to make it possible to install v2 versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/datastax/terraform-provider-astra
+module github.com/datastax/terraform-provider-astra/v2
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/datastax/terraform-provider-astra/internal/provider"
+	"github.com/datastax/terraform-provider-astra/v2/internal/provider"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 


### PR DESCRIPTION
If you run 
```go get github.com/datastax/terraform-provider-astra@v2.0.3```
you get
```go get: github.com/datastax/terraform-provider-astra@v2.0.3: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2```

[The manual says](https://therootcompany.com/blog/bump-go-package-to-v2/) that you must change a package name to make it to work.