### PR TITLE
issue-210: fix streaming tenant import

### DIFF
--- a/docs/resources/streaming_tenant.md
+++ b/docs/resources/streaming_tenant.md
@@ -30,12 +30,12 @@ resource "astra_streaming_tenant" "streaming_tenant-1" {
 - `cloud_provider` (String) Cloud provider
 - `region` (String) cloud region
 - `tenant_name` (String) Streaming tenant name.
-- `topic` (String) Streaming tenant topic.
 - `user_email` (String) User email for tenant.
 
 ### Optional
 
 - `deletion_protection` (Boolean) Whether or not to allow Terraform to destroy this tenant. Unless this field is set to false in Terraform state, a `terraform destroy` or `terraform apply` command that deletes the instance will fail. Defaults to `true`.
+- `topic` (String, Deprecated) Streaming tenant topic. Please use the `astra_streaming_topic` resource instead.
 
 ### Read-Only
 


### PR DESCRIPTION
Fixes #210 #220
- fix region diff
- ignore diffs related to topic, email, and deletion_protection, because these are not currently available via the read rest endpoint
- deprecate default topic, this shouldn't be used (fixes #220)