### PR TITLE
issue-225: improve CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,26 +1,22 @@
-name: Tests
+name: CI
 on:
   pull_request:
     paths-ignore:
       - 'README.md'
   push:
-    paths-ignore:
-      - 'README.md'
+    branches:
+      - 'main'
 jobs:
   build:
-    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
-      id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |
@@ -47,38 +43,29 @@ jobs:
         go build -v .
 
   # run acceptance tests in a matrix with Terraform core versions
-  test:
-    name: Matrix Test
+  terraform-acceptance-test:
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
-      fail-fast: false
+      max-parallel: 1
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '0.12.29'
-          - '0.13.4'
-          - '0.14.0-beta2'
-          - '0.15.0-dev'
+          # - '0.15.5'
+          - '1.4.6'
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
-      id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-    - name: Get dependencies
-      run: |
-        go mod download
-        
-    - name: TF acceptance tests
-      timeout-minutes: 10
+    - name: Run tests
+      timeout-minutes: 15
       env:
+        ASTRA_API_TOKEN: ${{ secrets.TEST_ASTRA_API_TOKEN }}
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}
       run: |
-        go test -v -cover ./internal/provider/
+        make testacc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test/test.env
+
 *.dll
 *.exe
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -4,28 +4,31 @@ PROVIDER=astra
 DEV_VERSION=0.0.1
 PLUGIN_PATH=registry.terraform.io/datastax/$(PROVIDER)/$(DEV_VERSION)/$(GOOS)_$(GOARCH)
 
+
 ifeq ($(GOOS), "windows")
         INSTALL_PATH=%APPDATA%/terraform.d/plugins/$(PLUGIN_PATH)
 else
         INSTALL_PATH=~/.terraform.d/plugins/$(PLUGIN_PATH)
 endif
 
-default: install
-
-install: build
-	mkdir -p $(INSTALL_PATH)
-	cp bin/terraform-provider-$(PROVIDER) $(INSTALL_PATH)
+default: build
 
 build:
 	mkdir -p bin
 	go build -o bin/terraform-provider-$(PROVIDER)
 
+install: build
+	mkdir -p $(INSTALL_PATH)
+	cp bin/terraform-provider-$(PROVIDER) $(INSTALL_PATH)
+
 dev: install
 
+test: testacc
+
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+	test/run_tests.sh
 
 clean:
-	rm bin/terraform-provider-$(PROVIDER)
+	rm -f bin/terraform-provider-$(PROVIDER)
 
-.PHONY: install build clean dev testacc
+.PHONY: install build clean dev test testacc

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ public servers.
 2. Build the provider binary
 
        cd $HOME/go/src/github.com/datastax/terraform-provider-astra
-       make build
+       make
 
 3. Create a new Terraform config file or run an existing one and the locally built
    provider will be used.  You may see a warning about using an unverified binary.
@@ -104,11 +104,31 @@ public servers.
    Note: `terraform init` should be skipped when developing locally.
 
 
-### Running the test suite
+### Running the tests
+
+The tests require several environment variables to be set in order to successfully
+run.  By default any tests which are missing the required environment variables
+will be skipped.
+
+    ```sh
+    export ASTRA_TEST_DATABASE_ID="<Astra database UUID>"
+    export ASTRA_TEST_DATACENTER_ID="<Astra datacenter id>"
+    export ASTRA_TEST_ENDPOINT_ID="<Astra endpoint ID>"
+    ```
+
+An example of these variables can be found in the file `test/example-test.env`.  If a
+file called `test/test.env` is created it will be automatically loaded by the test script.
 
 The tests can be run via Make.
 
-    make testacc
+    make test
+
+A single test can be run using golang test args.
+
+    ```sh
+    export TESTARGS="-run TestStreamingTenant"
+    make test
+    ```
 
 ## Documentation Updates
 

--- a/internal/provider/data_source_access_list_test.go
+++ b/internal/provider/data_source_access_list_test.go
@@ -2,28 +2,33 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestDataSourceAccessListEndpoints(t *testing.T){
+func TestDataSourceAccessListEndpoints(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+
 	resource.UniqueId()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivateAccessListDataSource(),
+				Config: testAccPrivateAccessListDataSource(databaseID),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccPrivateAccessListDataSource() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccPrivateAccessListDataSource(databaseID string) string {
 	return fmt.Sprintf(`
 data "astra_access_list" "dev" {
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
+  database_id = "%s"
 }
-`)
+`, databaseID)
 }

--- a/internal/provider/data_source_private_link_endpoints_test.go
+++ b/internal/provider/data_source_private_link_endpoints_test.go
@@ -2,30 +2,37 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestDataSourcePrivateLinkEndpoints(t *testing.T){
+func TestDataSourcePrivateLinkEndpoints(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID", "ASTRA_TEST_DATACENTER_ID", "ASTRA_TEST_ENDPOINT_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+	datacenterID := os.Getenv("ASTRA_TEST_DATACENTER_ID")
+	endpointID := os.Getenv("ASTRA_TEST_ENDPOINT_ID")
+
 	resource.UniqueId()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivateLinkEndpointsDataSource(),
+				Config: testAccPrivateLinkEndpointsDataSource(databaseID, datacenterID, endpointID),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccPrivateLinkEndpointsDataSource() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccPrivateLinkEndpointsDataSource(databaseID, datacenterID, endpointID string) string {
 	return fmt.Sprintf(`
 data "astra_private_link_endpoints" "dev" {
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
-  datacenter_id = "aba3cf20-d579-4091-a36d-9c9f75096031-1"
-  endpoint_id = "vpc-5fbb2e34"
+  database_id = "%s"
+  datacenter_id = "%s"
+  endpoint_id = "%s"
 }
-`)
+`, databaseID, datacenterID, endpointID)
 }

--- a/internal/provider/data_source_private_links_test.go
+++ b/internal/provider/data_source_private_links_test.go
@@ -2,28 +2,34 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestPrivateLinksDataSource(t *testing.T){
+func TestPrivateLinksDataSource(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID", "ASTRA_TEST_DATACENTER_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+	datacenterID := os.Getenv("ASTRA_TEST_DATACENTER_ID")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivateLinksDataSource(),
+				Config: testAccPrivateLinksDataSource(databaseID, datacenterID),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccPrivateLinksDataSource() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccPrivateLinksDataSource(databaseID, datacenterID string) string {
 	return fmt.Sprintf(`
 data "astra_private_links" "dev" {
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
-  datacenter_id = "aba3cf20-d579-4091-a36d-9c9f75096031-1"
+  database_id = "%s"
+  datacenter_id = "%s"
 }
-`)
+`, databaseID, datacenterID)
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,10 +1,11 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/terraform-providers/terraform-provider-aws/aws"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/terraform-providers/terraform-provider-aws/aws"
 )
 
 var testAccProviders map[string]*schema.Provider
@@ -14,7 +15,7 @@ func init() {
 	testAccProvider = New("1")()
 	testAccProviders = map[string]*schema.Provider{
 		"astra": testAccProvider,
-		"aws": aws.Provider(),
+		"aws":   aws.Provider(),
 	}
 	configure("dev", testAccProvider)
 }
@@ -22,13 +23,6 @@ func init() {
 func testAccPreCheck(t *testing.T) {
 	if err := os.Getenv("ASTRA_API_TOKEN"); err == "" {
 		t.Fatal("ASTRA_API_TOKEN must be set for acceptance tests")
-	}
-}
-
-func checkAwsEnv(t *testing.T) {
-	if os.Getenv("AWS_ACCESS_KEY_ID") == "" ||
-		os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
-		t.Fatal("`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` must be set for acceptance testing")
 	}
 }
 

--- a/internal/provider/resource_access_list_test.go
+++ b/internal/provider/resource_access_list_test.go
@@ -3,27 +3,32 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/datastax/astra-client-go/v2/astra"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"testing"
 )
 
-func TestAccessList(t *testing.T){
+func TestAccessList(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccessListConfiguration(),
+				Config: testAccAccessListConfiguration(databaseID),
 			},
 		},
 	})
 }
 
-func testAccAccessListConfiguration() string {
+func testAccAccessListConfiguration(databaseID string) string {
 	return fmt.Sprintf(`
 resource "astra_access_list" "example" {
-  database_id = "eab58043-d360-4797-bc0d-3cdde4884022"
+  database_id = "%s"
   addresses {
       address= "0.0.0.1/0"
       enabled= true
@@ -38,19 +43,19 @@ resource "astra_access_list" "example" {
   }
   enabled = true
 }
-`)
+`, databaseID)
 }
 
 func TestTimeUnmarshal(t *testing.T) {
 	msg := `{"lastUpdateDateTime":"2021-08-03 15:20:29.008 +0000 UTC"}`
 	//msg := `{"lastUpdateDateTime":"2021-08-03T15:20:29Z"}`
 	bodyBytes := []byte(msg)
-	type TestStruct struct{
+	type TestStruct struct {
 		LastUpdateDateTime *string
 	}
 	var dest TestStruct
 	if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-		fmt.Printf("fail with error: %s",err)
+		fmt.Printf("fail with error: %s", err)
 		return
 	}
 	fmt.Printf("succeed")
@@ -62,7 +67,7 @@ func TestMsgUnmarshal(t *testing.T) {
 
 	var dest astra.AccessListResponse
 	if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-		fmt.Printf("fail with error: %s",err)
+		fmt.Printf("fail with error: %s", err)
 		return
 	}
 
@@ -70,7 +75,7 @@ func TestMsgUnmarshal(t *testing.T) {
 
 }
 
-func TestMsgNewStructMarshal(t *testing.T){
+func TestMsgNewStructMarshal(t *testing.T) {
 	type AddressResponse struct {
 
 		// The address (ip address and subnet mask in CIDR notation) of the address to allow
@@ -104,17 +109,15 @@ func TestMsgNewStructMarshal(t *testing.T){
 		OrganizationId *string `json:"organizationId,omitempty"`
 	}
 
-
 	msg := `{"organizationId":"f9f4b1e0-4c05-451e-9bba-d631295a7f73","databaseId":"aba3cf20-d579-4091-a36d-9c9f75096031","addresses":[{"address":"0.0.0.0/0","description":"","enabled":true,"lastUpdateDateTime":"2021-08-03 15:20:29.008 +0000 UTC"}],"configurations":{"accessListEnabled":false}}`
 	bodyBytes := []byte(msg)
 
 	var dest MyAccessListResponse
 	if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-		fmt.Printf("fail with error: %s",err)
+		fmt.Printf("fail with error: %s", err)
 		return
 	}
 
 	fmt.Printf("succeed")
-
 
 }

--- a/internal/provider/resource_cdc_test.go
+++ b/internal/provider/resource_cdc_test.go
@@ -2,14 +2,18 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestCDC(t *testing.T){
+func TestCDC(t *testing.T) {
+	// Disable this test by default until test works with non-prod clusters
+	checkRequiredTestVars(t, "ASTRA_TEST_CDC_TEST_ENABLED")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCDCConfiguration(),
@@ -18,7 +22,7 @@ func TestCDC(t *testing.T){
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
 func testAccCDCConfiguration() string {
 	return fmt.Sprintf(`
 resource "astra_streaming_tenant" "streaming_tenant-1" {

--- a/internal/provider/resource_keyspace_test.go
+++ b/internal/provider/resource_keyspace_test.go
@@ -2,47 +2,47 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestKeyspace(t *testing.T){
+func TestKeyspace(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKeyspaceConfiguration(),
+				Config: testAccKeyspaceConfiguration(databaseID),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccKeyspaceConfiguration() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccKeyspaceConfiguration(databaseID string) string {
 	return fmt.Sprintf(`
 resource "astra_keyspace" "keyspace-1" {
   name        = "ks1"
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
+  database_id = "%s"
 
 }
 
 resource "astra_keyspace" "keyspace-2" {
   name        = "ks2"
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
+  database_id = "%s"
 
 }
 
 resource "astra_keyspace" "keyspace-3" {
   name        = "ks3"
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
+  database_id = "%s"
 
 }
 
-resource "astra_keyspace" "keyspace-4" {
-  name        = "ks4"
-  database_id = "aba3cf20-d579-4091-a36d-9c9f75096031"
-
-}
-`)
+`, databaseID, databaseID, databaseID)
 }

--- a/internal/provider/resource_private_link_endpoint_test.go
+++ b/internal/provider/resource_private_link_endpoint_test.go
@@ -2,14 +2,17 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestPrivateLinkEndpoint(t *testing.T){
+func TestPrivateLinkEndpoint(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_AWS_ACCESS_KEY_ID", "ASTRA_TEST_AWS_SECRET_ACCESS_KEY")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t); checkAwsEnv(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPrivateLinkEndpointConfiguration(),
@@ -18,7 +21,7 @@ func TestPrivateLinkEndpoint(t *testing.T){
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
 func testAccPrivateLinkEndpointConfiguration() string {
 	return fmt.Sprintf(`
 provider "aws" {
@@ -45,7 +48,7 @@ resource "astra_private_link_endpoint" "example" {
 `)
 }
 
-func TestParsePrivateLinkEndpointId(t *testing.T){
+func TestParsePrivateLinkEndpointId(t *testing.T) {
 	id := "b504911d-4982-4e45-84c2-607524cb533b/datacenter/b504911d-4982-4e45-84c2-607524cb533b-1/endpoint//subscriptions/123456/resourceGroups/123456/providers/Microsoft.Network/privateEndpoints/123456"
 	databaseID, datacenterID, endpointID, err := parsePrivateLinkEndpointID(id)
 	if err != nil {
@@ -61,7 +64,7 @@ func TestParsePrivateLinkEndpointId(t *testing.T){
 		t.Logf("Datacenter ID parsed from private link ID: \"%s\", expected \"%s\"", datacenterID, "b504911d-4982-4e45-84c2-607524cb533b-1")
 		t.Fail()
 	}
-	if (endpointID != "/subscriptions/123456/resourceGroups/123456/providers/Microsoft.Network/privateEndpoints/123456") {
+	if endpointID != "/subscriptions/123456/resourceGroups/123456/providers/Microsoft.Network/privateEndpoints/123456" {
 		t.Logf("endpoint ID parsed from private link ID: \"%s\", expected \"%s\"", endpointID, "/subscriptions/123456/resourceGroups/123456/providers/Microsoft.Network/privateEndpoints/123456")
 		t.Fail()
 	}

--- a/internal/provider/resource_private_link_test.go
+++ b/internal/provider/resource_private_link_test.go
@@ -2,34 +2,40 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestPrivateLink(t *testing.T){
+func TestPrivateLink(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID", "ASTRA_TEST_DATACENTER_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+	datacenterID := os.Getenv("ASTRA_TEST_DATACENTER_ID")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPrivateLinkConfiguration(),
+				Config: testAccPrivateLinkConfiguration(databaseID, datacenterID),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccPrivateLinkConfiguration() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccPrivateLinkConfiguration(databaseID, datacenterID string) string {
 	return fmt.Sprintf(`
 resource "astra_private_link" "example" {
   allowed_principals = ["community-ecosystem"]
-  database_id = "73cb628f-4b14-4343-b313-caab1c14e3f6"
-  datacenter_id = "73cb628f-4b14-4343-b313-caab1c14e3f6-1"
+  database_id = "%s"
+  datacenter_id = "%s"
 }
-`)
+`, databaseID, datacenterID)
 }
 
-func TestParsePrivateLinkId(t *testing.T){
+func TestParsePrivateLinkId(t *testing.T) {
 	id := "b504911d-4982-4e45-84c2-607524cb533b/datacenter/b504911d-4982-4e45-84c2-607524cb533b-1/serviceNames/projects/astra-serverless-prod-22/regions/us-east1/serviceAttachments/pl-prod"
 	databaseID, datacenterID, serviceName, err := parsePrivateLinkID(id)
 	if err != nil {
@@ -45,7 +51,7 @@ func TestParsePrivateLinkId(t *testing.T){
 		t.Logf("Datacenter ID parsed from private link ID: \"%s\", expected \"%s\"", datacenterID, "b504911d-4982-4e45-84c2-607524cb533b-1")
 		t.Fail()
 	}
-	if (serviceName != "projects/astra-serverless-prod-22/regions/us-east1/serviceAttachments/pl-prod") {
+	if serviceName != "projects/astra-serverless-prod-22/regions/us-east1/serviceAttachments/pl-prod" {
 		t.Logf("serviceName parsed from private link ID: \"%s\", expected \"%s\"", serviceName, "projects/astra-serverless-prod-22/regions/us-east1/serviceAttachments/pl-prod")
 		t.Fail()
 	}

--- a/internal/provider/resource_role_test.go
+++ b/internal/provider/resource_role_test.go
@@ -2,14 +2,18 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestRole(t *testing.T){
+func TestRole(t *testing.T) {
+	// Disable this test by default until it is configurable per user
+	checkRequiredTestVars(t, "ASTRA_TEST_ROLE_TEST_ENABLED")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRoleConfiguration(),
@@ -32,7 +36,6 @@ resource "astra_role" "example" {
 }
 `)
 }
-
 
 func testAccBiggerRoleConfiguration() string {
 	return fmt.Sprintf(`

--- a/internal/provider/resource_streaming_sink_test.go
+++ b/internal/provider/resource_streaming_sink_test.go
@@ -2,29 +2,35 @@ package provider
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"testing"
 )
 
-func TestStreamingSink(t *testing.T){
+func TestStreamingSink(t *testing.T) {
+	// Disable this test by default until test works with non-prod clusters
+	checkRequiredTestVars(t, "ASTRA_TEST_STREAMING_SINK_TEST_ENABLED")
+
+	//tenantName := fmt.Sprintf("terraform-test-%s", uuid.New().String())[0:20]
+	snowflakeTenantName := fmt.Sprintf("terraform-test-%s", uuid.New().String())[0:20]
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-//			{
-//				Config: testAccStreamingSinkConfiguration(),
-//			},
+			//			{
+			//				Config: testAccStreamingSinkConfiguration(),
+			//			},
 			{
-				Config: testAccStreamingSnowflakeSinkConfiguration(),
+				Config: testAccStreamingSnowflakeSinkConfiguration(snowflakeTenantName),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccStreamingSinkConfiguration() string {
-	tenantName := fmt.Sprintf("terraformtest-%s", uuid.New().String())[0:20]
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccStreamingSinkConfiguration(tenantName string) string {
 	return fmt.Sprintf(`
 resource "astra_streaming_tenant" "streaming_tenant-1" {
   tenant_name        = "%s"
@@ -64,8 +70,7 @@ resource "astra_streaming_sink" "streaming_sink-1" {
 }
 `, tenantName)
 }
-func testAccStreamingSnowflakeSinkConfiguration() string {
-	tenantName := fmt.Sprintf("snowflake-%s", uuid.New().String())[0:20]
+func testAccStreamingSnowflakeSinkConfiguration(tenantName string) string {
 	return fmt.Sprintf(`
 resource "astra_streaming_tenant" "streaming_tenant-1" {
   tenant_name        = "%s"
@@ -126,5 +131,5 @@ resource "astra_streaming_sink" "streaming_sink-1" {
     }
  })
 }
-`,tenantName, "%s", "%s", "%s")
+`, tenantName, "%s", "%s", "%s")
 }

--- a/internal/provider/resource_streaming_tenant.go
+++ b/internal/provider/resource_streaming_tenant.go
@@ -152,19 +152,12 @@ func resourceStreamingTenantDelete(ctx context.Context, resourceData *schema.Res
 	streamingClient := meta.(astraClients).astraStreamingClient.(*astrastreaming.ClientWithResponses)
 	client := meta.(astraClients).astraClient.(*astra.ClientWithResponses)
 
-	rawRegion := resourceData.Get("region").(string)
-	region := strings.ReplaceAll(rawRegion, "-", "")
-
-	cloudProvider := resourceData.Get("cloud_provider").(string)
-
 	id := resourceData.Id()
 
 	tenantID, err := parseStreamingTenantID(id)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	//tenantName:= resourceData.Get("tenant_name").(string)
 
 	orgBody, _ := client.GetCurrentOrganization(ctx)
 
@@ -177,7 +170,7 @@ func resourceStreamingTenantDelete(ctx context.Context, resourceData *schema.Res
 	}
 
 	params := astrastreaming.DeleteStreamingTenantParams{}
-	cluster := fmt.Sprintf("pulsar-%s-%s", cloudProvider, region)
+	cluster := resourceData.Get("cluster_name").(string)
 	deleteResponse, err := streamingClient.DeleteStreamingTenantWithResponse(ctx, tenantID, cluster, &params)
 	if err != nil {
 		return diag.FromErr(err)

--- a/internal/provider/resource_streaming_tenant_test.go
+++ b/internal/provider/resource_streaming_tenant_test.go
@@ -2,32 +2,36 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestStreamingTenant(t *testing.T){
+func TestStreamingTenant(t *testing.T) {
+	t.Parallel()
+	tenantName := "terraform-test-" + randomString(5)
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStreamingTenantConfiguration(),
+				Config: testAccStreamingTenantConfiguration(tenantName),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccStreamingTenantConfiguration() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccStreamingTenantConfiguration(tenantName string) string {
 	return fmt.Sprintf(`
 resource "astra_streaming_tenant" "streaming_tenant-1" {
-  tenant_name        = "terraformtest"
-  topic              = "terraformtest"
-  region             = "useast-4"
-  cloud_provider     = "gcp"
-  user_email         = "seb@datastax.com"
+  tenant_name         = "%s"
+  topic               = "topic-1"
+  region              = "useast-4"
+  cloud_provider      = "gcp"
+  user_email          = "terraform-test-user@datastax.com"
+  deletion_protection = false
 }
-
-`)
+`, tenantName)
 }

--- a/internal/provider/resource_streaming_topic_test.go
+++ b/internal/provider/resource_streaming_topic_test.go
@@ -2,32 +2,48 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestStreamingTopic(t *testing.T){
+func TestStreamingTopic(t *testing.T) {
+	// Disable this test by default until test works with non-prod clusters
+	checkRequiredTestVars(t, "ASTRA_TEST_STREAMING_TOPIC_TEST_ENABLED")
+
+	t.Parallel()
+	tenantName := "terraform-test-" + randomString(5)
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStreamingTopicConfiguration(),
+				Config: testAccStreamingTopicConfiguration(tenantName),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccStreamingTopicConfiguration() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccStreamingTopicConfiguration(tenantName string) string {
 	return fmt.Sprintf(`
+resource "astra_streaming_tenant" "streaming_tenant_1" {
+  tenant_name         = "%s"
+  topic               = "default-topic-1"
+  region              = "useast-4"
+  cloud_provider      = "gcp"
+  user_email          = "terraform-test-user@datastax.com"
+  deletion_protection = false
+}
+
 resource "astra_streaming_topic" "streaming_topic-1" {
-  tenant_name        = "terraformtest2"
+  tenant_name        = astra_streaming_tenant.streaming_tenant_1.tenant_name
   topic              = "testtopic"
   region             = "useast-4"
   cloud_provider     = "gcp"
   namespace          = "default"
 }
 
-`)
+`, tenantName)
 }

--- a/internal/provider/resource_table_test.go
+++ b/internal/provider/resource_table_test.go
@@ -2,35 +2,34 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestTable(t *testing.T){
+func TestTable(t *testing.T) {
+	checkRequiredTestVars(t, "ASTRA_TEST_DATABASE_ID")
+	databaseID := os.Getenv("ASTRA_TEST_DATABASE_ID")
+
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccTableConfiguration(),
+				Config: testAccTableConfiguration(databaseID),
 			},
 		},
 	})
 }
 
-//https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
-func testAccTableConfiguration() string {
+// https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html
+func testAccTableConfiguration(databaseID string) string {
 	return fmt.Sprintf(`
-resource "astra_database" "dev" {
-  name           = "puppies"
-  keyspace       = "puppies"
-  cloud_provider = "gcp"
-  regions        = ["us-east1"]
-}
 resource "astra_table" "table-1" {
   table       = "mytable"
   keyspace = "puppies"
-  database_id = astra_database.dev.id
+  database_id = "%s"
   region = "us-east1"
   clustering_columns = "a:b"
   partition_keys = "c:d"
@@ -67,5 +66,5 @@ resource "astra_table" "table-1" {
     }
   ]
 }
-`)
+`, databaseID)
 }

--- a/internal/provider/resource_token_test.go
+++ b/internal/provider/resource_token_test.go
@@ -2,14 +2,15 @@ package provider
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestToken(t *testing.T){
+func TestToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTokenConfiguration(),
@@ -20,8 +21,15 @@ func TestToken(t *testing.T){
 
 func testAccTokenConfiguration() string {
 	return fmt.Sprintf(`
+resource "astra_role" "example" {
+  role_name = "example-role"
+  description = "test role"
+  effect = "allow"
+  resources = []
+  policy = ["org-db-view"]
+}
 resource "astra_token" "example" {
-  roles = ["a8cd363d-5069-4a2b-86d8-0578139812ac"]
+  roles = [astra_role.example.role_id]
 }
 `)
 }

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -3,8 +3,11 @@ package provider
 import (
 	"crypto/sha256"
 	"fmt"
+	"math/rand"
+	"os"
 	"sort"
 	"strings"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -22,4 +25,23 @@ func keyFromStrings(s []string) string {
 
 func protectedFromDelete(resourceData *schema.ResourceData) bool {
 	return resourceData.Get("deletion_protection").(bool)
+}
+
+// checkRequiredTestVars returns true if the given environment variables are not empty
+func checkRequiredTestVars(t *testing.T, vars ...string) {
+	for _, v := range vars {
+		if strings.TrimSpace(os.Getenv(v)) == "" {
+			t.Skipf("skipping test due to missing %s environment variable", v)
+		}
+	}
+}
+
+// randomString returns a random string of length n
+func randomString(n int) string {
+	var chars = []rune("0123456789abcdefghijklmnopqrstuvwxyz")
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = chars[rand.Intn(len(chars))]
+	}
+	return string(s)
 }

--- a/test/example-test.env
+++ b/test/example-test.env
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Example configuration for running tests
+# These variables can be set manually in the environment running the tests, or
+# this file can be copied `test.env` making changes as needed.
+# Note: it's not necessary to set all values, only set the values which are applicable to the
+# desired tests to run.
+
+# Allows use of alternate Astra endpoints
+ASTRA_API_URL=
+ASTRA_STREAMING_API_URL=
+
+# Used for tests which require an existing database
+ASTRA_TEST_DATABASE_ID=aba3cf20-d579-4091-a36d-9c9f75096031
+ASTRA_TEST_DATACENTER_ID=aba3cf20-d579-4091-a36d-9c9f75096031-1
+ASTRA_TEST_ENDPOINT_ID=vpc-5fbb2e34
+
+# Used for tests which create a new database
+ASTRA_TEST_DATABASE_NAME=terraform-testdb
+
+# Used for tests which require an existing streaming tenant
+ASTRA_TEST_STREAMING_TENANT=terraform-test-1
+
+# Used for tests which require direct AWS resource access such as private link configuration
+ASTRA_TEST_AWS_ACCESS_KEY_ID=1234
+ASTRA_TEST_AWS_SECRET_ACCESS_KEY=foobar

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -o allexport errexit
+
+DEFAULT_TEST_ENV_FILE="test.env"
+DEFAULT_TEST_ASTRA_API_URL="https://api.test.cloud.datastax.com"
+DEFAULT_TEST_ASTRA_STREAMING_API_URL="https://api.staging.streaming.datastax.com"
+
+setup_env() {
+  if [ -z "$TEST_ENV_FILE" ]; then
+    TEST_ENV_FILE="$DEFAULT_TEST_ENV_FILE"
+  fi
+  if [ -f "$TEST_ENV_FILE" ]; then
+    source "$TEST_ENV_FILE"
+  else
+    echo "file '$TEST_ENV_FILE' not found, some tests may be skipped"
+  fi
+
+  if [ -z "$ASTRA_API_TOKEN" ]; then \
+      echo "environment variable ASTRA_API_TOKEN must be set for acceptance tests"
+      exit 1
+  fi
+
+  if [ -z "$ASTRA_API_URL" ]; then
+    ASTRA_API_URL="$DEFAULT_TEST_ASTRA_API_URL"
+  fi
+  if [ -z "$ASTRA_STREAMING_API_URL" ]; then
+    ASTRA_STREAMING_API_URL="$DEFAULT_TEST_ASTRA_STREAMING_API_URL"
+  fi
+
+  if [ -z "$ASTRA_TEST_TIMEOUT" ]; then
+    ASTRA_TEST_TIMEOUT="15m"
+  fi
+}
+
+run_tests() {
+  echo "Running tests..."
+  TF_ACC=1 # Environment variable to enable terraform acceptance tests
+  go test ./internal/provider -v $TESTARGS -timeout "$ASTRA_TEST_TIMEOUT"
+}
+
+# Main execution
+setup_env
+run_tests


### PR DESCRIPTION
- simplify github CI and test on recent Terraform versions
- allow test configuration using environment variables
- skip tests for which the required environment vars are not present
- disable by default tests which currently aren't working in the test environment
- add more details to readme about how to run tests

Fixes #225 