### PR TITLE
mark astra token provider field as sensitive

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -74,6 +74,7 @@ func New(version string) func() *schema.Provider {
 					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("ASTRA_API_TOKEN", nil),
 					Description: "Authentication token for Astra API.",
+					Sensitive:   true,
 				},
 				"astra_api_url": {
 					Type:        schema.TypeString,


### PR DESCRIPTION
This prevents the token from being displayed in the Terraform UI output such as logs.