### PR TITLE
increase default database create timeout to 40 min

### DIFF
--- a/internal/provider/resource_database.go
+++ b/internal/provider/resource_database.go
@@ -22,10 +22,10 @@ var availableCloudProviders = []string{
 	"azure",
 }
 
-var databaseCreateTimeout = time.Minute * 20
+var databaseCreateTimeout = time.Minute * 40
 var databaseReadTimeout = time.Minute * 5
 var databaseDeleteTimeout = time.Minute * 20
-var databaseUpdateTimeout = time.Minute * 20
+var databaseUpdateTimeout = time.Minute * 40
 
 func resourceDatabase() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
Database creation can take a long time, especially when creating a database with multiple regions.  This increases the default database create timeout from 20 min -> 40 min.