### PR TITLE
document minimum terraform version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        # list whatever Terraform versions here you would like to support
+        # Test with min and max supported Terraform versions
         terraform:
-          # - '0.15.5'
-          - '1.4.6'
+          - '1.0.11'
+          - '1.5.3'
     steps:
     - uses: actions/setup-go@v4
       with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,10 @@ provider "astra" {
 }
 ```
 
+## Requirements
+
+Terraform 1.0 and higher
+
 ## Additional Info
 
 To report bugs or feature requests for the provider [file an issue on github](https://github.com/datastax/terraform-provider-astra/issues).

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -19,6 +19,10 @@ description: |-
 
   {{tffile "examples/provider/provider.tf"}}
 
+## Requirements
+
+Terraform 1.0 and higher
+
 ## Additional Info
 
 To report bugs or feature requests for the provider [file an issue on github](https://github.com/datastax/terraform-provider-astra/issues).


### PR DESCRIPTION
Fixes #226
After switching to the terraform plugin framework and the version 6 terraform plugin protocol, we require Terraform client 1.0 and higher.