### PR TITLE
run terraform fmt during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,25 +14,32 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.19'
+
+    - uses: hashicorp/setup-terraform@v2
+      with:
+        # This setting is necessary to avoid errors during doc generation.  See https://github.com/hashicorp/terraform-plugin-docs/issues/127
+        terraform_wrapper: false
 
     - uses: actions/checkout@v3
-
-    - name: Install tfplugindocs
-      run: |
-        go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
     - name: Run doc generation
       id: doc_gen
       run: |
-        make docs && echo "::set-output name=local_changes::$(git status --porcelain ./docs | wc -l)"
+        make docs && echo "uncommitted_files=$(git status --porcelain ./docs ./examples | wc -l)" >> $GITHUB_OUTPUT
 
-    - name: Uncommitted changes Check
-      if: ${{ steps.doc_gen.outputs.local_changes != 0 }}
+    - name: Show uncommitted changes
+      if: ${{ steps.doc_gen.outputs.uncommitted_files != 0 }}
+      run:
+        echo "Found uncommitted doc changes"
+        git status --porcelain ./docs ./examples
+
+    - name: Uncommitted changes check
+      if: ${{ steps.doc_gen.outputs.uncommitted_files != 0 }}
       uses: actions/github-script@v6
       with:
         script: |
-          core.setFailed('tfplugindocs generated uncommitted doc changes. Please run tfplugindocs and add doc changes to your commits.')
+          core.setFailed('tfplugindocs generated uncommitted doc changes. Please run 'make docs' and add doc changes to your commits.')
 
   build:
     runs-on: ubuntu-latest
@@ -41,7 +48,7 @@ jobs:
 
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.19'
 
     - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOARCH=$(shell go env GOARCH)
 PROVIDER=astra
 DEV_VERSION=0.0.1
 PLUGIN_PATH=registry.terraform.io/datastax/$(PROVIDER)/$(DEV_VERSION)/$(GOOS)_$(GOARCH)
-TF_PLUGIN_DOCS_VERSION=v0.15.0
+TF_PLUGIN_DOCS_VERSION=v0.16.0
 
 
 ifeq ($(GOOS), "windows")
@@ -34,8 +34,10 @@ clean:
 
 tools:
 	go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@$(TF_PLUGIN_DOCS_VERSION)
+	type terraform || (echo "'terraform' command not found, please install it" && exit 1)
 
 docs: tools
-	~/go/bin/tfplugindocs
+	terraform fmt --recursive ./examples
+	tfplugindocs
 
 .PHONY: install build clean dev docs test testacc tools

--- a/main.go
+++ b/main.go
@@ -14,13 +14,23 @@ import (
 
 const providerName = "datastax/astra"
 
+// Run "go generate" to format example terraform files and generate the docs for the registry/website
+
+// If you do not have terraform installed, you can remove the formatting command, but its suggested to
+// ensure the documentation is formatted properly.
+//go:generate terraform fmt -recursive ./examples/
+
+// Run the docs generation tool, check its repository for more information on how it works and how docs
+// can be customized.
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+
 var (
 	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary
+	// to appropriate values for the compiled binary.
 	version string = "dev"
 
-	// goreleaser can also pass the specific commit if you want
-	// commit  string = ""
+	// goreleaser can pass other information to the main package, such as the specific commit
+	// https://goreleaser.com/cookbooks/using-main.version/
 )
 
 func main() {


### PR DESCRIPTION
- run terraform fmt against the ./examples directory during CI
- check for any diffs compared to latest commit
- fix deprecation warning related to the 'set-output' command
- add go:generate settings to main.go based on recommendations in provider examples