### PR TITLE
private-link: check for deleted db

### DIFF
--- a/internal/provider/resource_private_link.go
+++ b/internal/provider/resource_private_link.go
@@ -144,8 +144,7 @@ func resourcePrivateLinkRead(ctx context.Context, d *schema.ResourceData, meta i
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
-	if string(*privateLinks.ServiceName) == serviceName {
+	if privateLinks != nil && string(*privateLinks.ServiceName) == serviceName {
 		if err := setPrivateLinkData(d, databaseID, datacenterID, serviceName, privateLinks.AllowedPrincipals); err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
If the database is in a Terminated state, the list of private links returned will be nil. This adds a check for that nil value and will result in removing the private link from the local state because the remote private link has been deleted.