### PR TITLE
issue-227: improve error handling for access list resource

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -147,7 +147,7 @@ func configure(providerVersion string, p *schema.Provider) func(context.Context,
 		retryClient.RetryMax = 10
 		retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
 			// Never retry POST requests because of side effects
-			if resp.Request.Method == "POST" {
+			if resp != nil && resp.Request.Method == "POST" {
 				return false, err
 			}
 			return retryablehttp.DefaultRetryPolicy(ctx, resp, err)

--- a/internal/provider/resource_access_list.go
+++ b/internal/provider/resource_access_list.go
@@ -168,7 +168,7 @@ func resourceAccessListRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	if string(*accessList.DatabaseId) == databaseID {
+	if accessList != nil && string(*accessList.DatabaseId) == databaseID {
 		if err := setAccessListData(d, accessList); err != nil {
 			return diag.FromErr(err)
 		}

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -13,6 +13,7 @@ setup_env() {
     TEST_ENV_FILE="${SCRIPT_PATH}/${DEFAULT_TEST_ENV_FILE}"
   fi
   if [ -f "$TEST_ENV_FILE" ]; then
+    echo "loading config from file $TEST_ENV_FILE"
     source "$TEST_ENV_FILE"
   else
     echo "file '$TEST_ENV_FILE' not found, some tests may be skipped"


### PR DESCRIPTION
Fixes #227 

Due to a bug in the astra go client, if the server responds with a 403 due to limited permissions, a JSON parsing error is reported to the user instead of reporting the actual permissions issue.  This works around that by moving the response parsing code into the terraform provider.

This also adds a couple of nil pointer checks to prevent plugin crashes in certain situations.