### PR TITLE
issue-193: streaming sink improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,9 @@
             "mode": "debug",
             // this assumes your workspace is the root of the repo
             "program": "${workspaceFolder}",
-            "env": {},
+            "env": {
+                "ASTRA_API_TOKEN": "<mytoken>",
+            },
             "args": [
                 // pass the debug flag for reattaching
                 "-debug",

--- a/docs/resources/streaming_sink.md
+++ b/docs/resources/streaming_sink.md
@@ -90,6 +90,7 @@ resource "astra_streaming_sink" "streaming_sink" {
 
 ### Optional
 
+- `archive` (String) Name of the sink archive type to use. Defaults to the value of sink_name.  Must be formatted as a URL, e.g. 'builtin://jdbc-clickhouse
 - `deletion_protection` (Boolean) Whether or not to allow Terraform to destroy this streaming sink. Unless this field is set to false in Terraform state, a `terraform destroy` or `terraform apply` command that deletes the instance will fail. Defaults to `true`.
 
 ### Read-Only


### PR DESCRIPTION
- allow multiple sinks of the same type with arbitrary names
- check all errors and improve error messages
- remove builtin sink check because this can be done by the backend

Fixes #193 