### PR TITLE
issue-222: improve error handling

### DIFF
--- a/internal/provider/resource_database.go
+++ b/internal/provider/resource_database.go
@@ -339,7 +339,7 @@ func resourceDatabaseDelete(ctx context.Context, resourceData *schema.ResourceDa
 
 		// All other status codes > 200 NOT retried
 		if res.StatusCode() > http.StatusOK || res.JSON200 == nil {
-			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
+			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database, status code: %d, message %s", res.StatusCode(), string(res.Body)))
 		}
 
 		// Return when the database is in a TERMINATED state
@@ -489,7 +489,7 @@ func waitForDatabaseAndUpdateResource(ctx context.Context, resourceData *schema.
 
 		// Status code > 200 NOT retried
 		if res.StatusCode() > http.StatusOK || res.JSON200 == nil {
-			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
+			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database, status code: %d, message %s", res.StatusCode(), string(res.Body)))
 		}
 
 		// Success fetching database

--- a/internal/provider/resource_keyspace.go
+++ b/internal/provider/resource_keyspace.go
@@ -71,7 +71,7 @@ func resourceKeyspaceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 		// Status code > 200 NOT retried
 		if res.StatusCode() > 200 || res.JSON200 == nil {
-			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
+			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database, status code: %d, message %s", res.StatusCode(), string(res.Body)))
 		}
 
 		// Success fetching database
@@ -163,7 +163,7 @@ func resourceKeyspaceDelete(ctx context.Context, d *schema.ResourceData, meta in
 
 		// Status code > 200 NOT retried
 		if res.StatusCode() > 200 || res.JSON200 == nil {
-			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
+			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database, status code: %d, message %s", res.StatusCode(), string(res.Body)))
 		}
 
 		// Success fetching database

--- a/internal/provider/resource_table.go
+++ b/internal/provider/resource_table.go
@@ -170,7 +170,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		// Status code > 200 NOT retried
 		if res.StatusCode() > 200 || res.JSON200 == nil {
-			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database: %s", string(res.Body)))
+			return retry.NonRetryableError(fmt.Errorf("unexpected response fetching database, status code: %d, message %s", res.StatusCode(), string(res.Body)))
 		}
 
 		// Success fetching database
@@ -186,7 +186,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 				if resp != nil {
 					b, _ = io.ReadAll(resp.Body)
 				}
-				return retry.NonRetryableError(fmt.Errorf("Error adding table (not retrying) err: %s,  body: %s", err, b))
+				return retry.NonRetryableError(fmt.Errorf("error adding table (not retrying) err: %s,  body: %s", err, b))
 			} else if resp.StatusCode == 409 {
 				// DevOps API returns 409 for concurrent modifications, these need to be retried.
 				b, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
Print the HTTP status code when there is an error fetching database status.
Fixes #222 