### PR TITLE
streaming: handle importing topics with dot

### DIFF
--- a/internal/provider/resource_streaming_topic.go
+++ b/internal/provider/resource_streaming_topic.go
@@ -578,8 +578,8 @@ func (t *StreamingTopicResourceModel) generateStreamingTopicID() string {
 }
 
 var (
-	streamingTopicIDPattern = `([a-z][a-z0-9-]*):(persistent|non-persistent)://` +
-		`([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)`
+	streamingTopicIDPattern = `^([a-z][a-z0-9-]*):(persistent|non-persistent)://` +
+		`([a-z][a-z0-9-]*)/([a-z][a-z0-9-]*)/([a-z][a-z0-9-._]*)$`
 	streamingTopicIDRegex = regexp.MustCompile(streamingTopicIDPattern)
 )
 


### PR DESCRIPTION
Handle dots and underscore in topic name.  Make sure we match the full topic ID string instead of partial.