### PR TITLE
fix go version for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20
+          go-version: '1.20'
 
       - name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
Without quotes, the go version is interpreted as a number, so version 1.20 becomes 1.2. This needs to be quotes to preserve the minor version (20).