### PR TITLE
streaming auth improvements

### DIFF
--- a/internal/provider/resource_streaming_topic.go
+++ b/internal/provider/resource_streaming_topic.go
@@ -265,25 +265,7 @@ func (r *StreamingTopicResource) Create(ctx context.Context, req resource.Create
 
 	pulsarClient := r.clients.pulsarAdminClient
 
-	astraOrgID, err := getCurrentOrgID(ctx, r.clients.astraClient)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating topic",
-			"Could not get current Astra organization: "+err.Error(),
-		)
-		return
-	}
-
-	pulsarToken, err := getLatestPulsarToken(ctx, r.clients.astraStreamingClient, r.clients.token, astraOrgID, cluster, tenant)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error creating topic",
-			"Could not get pulsar token: "+err.Error(),
-		)
-		return
-	}
-
-	streamingRequestHeaders := setPulsarClusterHeaders("", cluster, pulsarToken)
+	streamingRequestHeaders := setPulsarClusterHeaders(cluster)
 
 	if plan.Persistent.ValueBool() {
 		if plan.Partitioned.ValueBool() {
@@ -350,24 +332,6 @@ func (r *StreamingTopicResource) Read(ctx context.Context, req resource.ReadRequ
 
 	pulsarClient := r.clients.pulsarAdminClient
 
-	astraOrgID, err := getCurrentOrgID(ctx, r.clients.astraClient)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading topic",
-			"Could not get current Astra organization: "+err.Error(),
-		)
-		return
-	}
-
-	pulsarToken, err := getLatestPulsarToken(ctx, r.clients.astraStreamingClient, r.clients.token, astraOrgID, cluster, tenant)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading topic",
-			"Could not get pulsar token: "+err.Error(),
-		)
-		return
-	}
-
 	// Default to persistent true and partitioned false for compatibility with older provider versions
 	if state.Persistent.IsNull() {
 		state.Persistent = types.BoolValue(true)
@@ -376,7 +340,7 @@ func (r *StreamingTopicResource) Read(ctx context.Context, req resource.ReadRequ
 		state.Partitioned = types.BoolValue(false)
 	}
 
-	streamingRequestHeaders := setPulsarClusterHeaders("", cluster, pulsarToken)
+	streamingRequestHeaders := setPulsarClusterHeaders(cluster)
 
 	if state.Persistent.ValueBool() {
 		if state.Partitioned.ValueBool() {
@@ -504,25 +468,7 @@ func (r *StreamingTopicResource) Delete(ctx context.Context, req resource.Delete
 
 	pulsarClient := r.clients.pulsarAdminClient
 
-	astraOrgID, err := getCurrentOrgID(ctx, r.clients.astraClient)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting topic",
-			"Could not get current Astra organization: "+err.Error(),
-		)
-		return
-	}
-
-	pulsarToken, err := getLatestPulsarToken(ctx, r.clients.astraStreamingClient, r.clients.token, astraOrgID, cluster, tenant)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error deleting topic",
-			"Could not get pulsar token: "+err.Error(),
-		)
-		return
-	}
-
-	pulsarRequestEditor := setPulsarClusterHeaders("", cluster, pulsarToken)
+	pulsarRequestEditor := setPulsarClusterHeaders(cluster)
 
 	if state.Persistent.ValueBool() {
 		if state.Partitioned.ValueBool() {

--- a/internal/provider/util_streaming.go
+++ b/internal/provider/util_streaming.go
@@ -20,21 +20,9 @@ const (
 )
 
 // setPulsarClusterHeaders returns a function that can be used to set the request headers for a Pulsar admin API requests.
-// This overrides the provider Authorization header because the Pulsar admin API requires a Pulsar token instead of the AstraCS
-// token required by the Astra API.
-func setPulsarClusterHeaders(organizationID, cluster, pulsarToken string) func(ctx context.Context, req *http.Request) error {
+func setPulsarClusterHeaders(cluster string) func(ctx context.Context, req *http.Request) error {
 	return func(ctx context.Context, req *http.Request) error {
-		if pulsarToken == "" {
-			return fmt.Errorf("missing required pulsar token")
-		}
-		req.Header.Set(authHeader, fmt.Sprintf("Bearer %s", pulsarToken))
-		if cluster == "" {
-			return fmt.Errorf("missing required pulsar cluster name")
-		}
 		req.Header.Set(pulsarClusterHeader, cluster)
-		if organizationID != "" {
-			req.Header.Set(organizationHeader, organizationID)
-		}
 		return nil
 	}
 }


### PR DESCRIPTION
The Astra Pulsar admin API now allows authentication directly with an Astra token, so it's no longer necessary to retrieve a Pulsar token before performing admin operations.