### PR TITLE
fix astra token integration test

### DIFF
--- a/internal/provider/resource_token.go
+++ b/internal/provider/resource_token.go
@@ -39,6 +39,7 @@ func resourceToken() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 			},
 			"client_id": {
 				Description: "Client id, use as username in cql to connect",


### PR DESCRIPTION
The token integration test started failing after the addition of the optional `org_id` field (https://github.com/datastax/terraform-provider-astra/pull/399). The initial token creation works successfully but subsequent calls to Terraform apply cause the token to be regenerated instead of re-using the previously generated token. Adding the `Computed: true` flag fixes this issue by indicating to the Terraform SDK that the field was automatically generated from the auth token.