### PR TITLE
update goreleaser config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ website/vendor
 *.winfile eol=crlf
 
 terraform-provider-astra
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
+
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -47,8 +49,8 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-release:
+release: {}
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
The older goreleaser config is no longer supported.
```
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser release --clean
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.3.2/x64/goreleaser' failed with exit code 1
```
