### PR TITLE
Update docs for astra_enterprise_org

### DIFF
--- a/docs/resources/enterprise_org.md
+++ b/docs/resources/enterprise_org.md
@@ -18,7 +18,6 @@ resource "astra_enterprise_org" "entorg" {
   name          = "My Enterprise Organization"
   email         = "admin@example.com"
   admin_user_id = "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
-  enterprise_id = "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
 }
 ```
 
@@ -46,6 +45,7 @@ resource "astra_enterprise_org" "entorg" {
 Import is supported using the following syntax:
 
 ```shell
-# The import ID is the organization ID (UUID)
-terraform import astra_enterprise_org.example a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+**NOTE** Import of astra_enterprise_org resources is currently not available, and
+has not been available in previous versions of the provider, up to and including
+version 2.3.11.
 ```

--- a/examples/resources/astra_enterprise_org/import.sh
+++ b/examples/resources/astra_enterprise_org/import.sh
@@ -1,2 +1,3 @@
-# The import ID is the organization ID (UUID)
-terraform import astra_enterprise_org.example a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+**NOTE** Import of astra_enterprise_org resources is currently not available, and
+has not been available in previous versions of the provider, up to and including
+version 2.3.11.

--- a/examples/resources/astra_enterprise_org/resource.tf
+++ b/examples/resources/astra_enterprise_org/resource.tf
@@ -3,5 +3,4 @@ resource "astra_enterprise_org" "entorg" {
   name          = "My Enterprise Organization"
   email         = "admin@example.com"
   admin_user_id = "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
-  enterprise_id = "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
 }


### PR DESCRIPTION
This patch updates the registry docs to indicate that import is not currently supported for astra_enterprise_org objects as there is no READ operation currently in the DevOps API