### PR TITLE
remove tar.gz archives from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- formats: ["zip", "tar.gz"]
+- formats: ["zip"]
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
There is a known issue where adding tar.gz or other archives can sometimes create a bad release because Terraform only supports zip. https://github.com/hashicorp/terraform/issues/26282