### PR TITLE
fix(docs): typo in resource documentation. parked -> park

### DIFF
--- a/docs/resources/pcu_group.md
+++ b/docs/resources/pcu_group.md
@@ -25,7 +25,7 @@ resource "astra_pcu_group" "example" {
   description       = "PCU group for production databases"
   # You can uncomment the line below to park the group
   # The group must be created first as a resource before parking can be performed successfully
-  # parked = true
+  # park = true
 }
 
 # Create a PCU group with custom settings

--- a/examples/resources/astra_pcu_group/resource.tf
+++ b/examples/resources/astra_pcu_group/resource.tf
@@ -10,7 +10,7 @@ resource "astra_pcu_group" "example" {
   description       = "PCU group for production databases"
   # You can uncomment the line below to park the group
   # The group must be created first as a resource before parking can be performed successfully
-  # parked = true
+  # park = true
 }
 
 # Create a PCU group with custom settings


### PR DESCRIPTION
In the astra_pcu_group resource we had a typo in the example. This could
be confusing to users as "parked" is not a valid value, but "park" is a
valid value. This is just a docs change. Fixes #491 
